### PR TITLE
エラーの解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # messaging-api
 
-外部公開するために
+## 外部公開する
 
 - ngrokのインストール
 ```
@@ -16,3 +16,8 @@ ngrok authtoken <your_auth_token>
 ```
 ngrok http 3030
 ```
+## その他
+- 公式アカウント
+https://www.linebiz.com/jp/login/
+
+- Devコンソール

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ app.get("/", (req, res) => {
 app.post("/webhook", function(req, res) {
   res.send("HTTP POST request sent to the webhook URL!")
 
+  if (req.body.events[0].type === "message") {
+
   // 応答トークンを受け取る
   const dataString = JSON.stringify({
     replyToken: req.body.events[0].replyToken,
@@ -36,7 +38,7 @@ app.post("/webhook", function(req, res) {
       }
     ]
   })
-  
+
   // ユーザの返信をpostするためのリクエストヘッダの作成
   const headers = {
     "Content-Type": "application/json",
@@ -56,6 +58,7 @@ app.post("/webhook", function(req, res) {
     res.on("data", (d) => {
       process.stdout.write(d)
     })
+  })
 
     // リクエスト送信時のエラーをキャッチ
     request.on("error", (err) => {
@@ -65,9 +68,7 @@ app.post("/webhook", function(req, res) {
     // 定義したリクエストの送信
     request.write(dataString)
     request.end()
-  })
-
-
+  }
 })
 
 app.listen(PORT, () => {


### PR DESCRIPTION
[webhookの検証](https://developers.line.biz/ja/docs/messaging-api/nodejs-sample/#verify-webhook-url)は成功とでるが、公式アカウントにメッセージを送信しても期待するメッセージが返ってこない。
検証の際に以下のようなエラーログが出ている。が、これは単に検証だからイベントを送っておらず(?)`req.body.events[0]`の値が含まれていないことによるエラーになっているっぽい?
```
Example app listening at http://localhost:3030
TypeError: Cannot read properties of undefined (reading 'replyToken')
    at /Users/koyama/Desktop/messaging-api/index.js:27:36
    at Layer.handle [as handle_request] (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/route.js:144:13)
    at Route.dispatch (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/route.js:114:3)
    at Layer.handle [as handle_request] (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/layer.js:95:5)
    at /Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/index.js:284:15
    at Function.process_params (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/index.js:280:10)
    at urlencodedParser (/Users/koyama/Desktop/messaging-api/node_modules/body-parser/lib/types/urlencoded.js:82:7)
    at Layer.handle [as handle_request] (/Users/koyama/Desktop/messaging-api/node_modules/express/lib/router/layer.js:95:5)
```